### PR TITLE
Fix typo in linear regression docstring

### DIFF
--- a/previs/models/BaselineRegressors.py
+++ b/previs/models/BaselineRegressors.py
@@ -38,7 +38,7 @@ def linear_regression(X_train, y_train,
     @param y_train: Training dataset output
     @param X_val: Validation dataset input
     @param y_val: Validation dataset output
-    @return: The trained model, MAE, MSE and srt(MSE)
+    @return: The trained model, MAE, MSE and sqrt(MSE)
     """
     regressor = LinearRegression()
     regressor.fit(X_train, y_train)


### PR DESCRIPTION
## Summary
- Correct spelling in linear regression docstring from `srt(MSE)` to `sqrt(MSE)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d8e4dba5c832a9b58291cc9ebf578